### PR TITLE
fix: make no internet container scrollable to prevent content clipping

### DIFF
--- a/app/src/main/java/dev/sayed/mehrabalmomen/presentation/components/NoInternetContainer.kt
+++ b/app/src/main/java/dev/sayed/mehrabalmomen/presentation/components/NoInternetContainer.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -27,7 +29,14 @@ fun NoInternetContainer(
 ) {
     val isDark = Theme.isDark
     val icon = if (isDark) R.drawable.no_internet_dark else R.drawable.ic_no_internet
-    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState(), overscrollEffect = null)
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
         Image(
             modifier = Modifier.size(height = 100.dp, width = 120.dp),
             painter = painterResource(icon),


### PR DESCRIPTION
## Problem
The "No Internet" container in the Islamic Radio section had its content clipped at the bottom. The retry button was partially hidden and inaccessible, especially on smaller screen sizes.
## Root Cause
The `Column` composable was not scrollable, causing overflow content to be cut off without any way for the user 
to reach it.
## Solution
- Wrapped the `Column` with `verticalScroll(rememberScrollState())` to allow scrolling when content overflows
- Added `fillMaxSize()` to ensure the layout occupies the full screen and the user can scroll from any part of the screen
- Added `padding(16.dp)` to provide breathing room around the content and give it a better look
- Set `verticalArrangement = Arrangement.Center` to keep content centered when it fits within the screen
## Before / After
### Before
<img width="2340" height="1080" alt="Screenshot_20260414_215647" src="https://github.com/user-attachments/assets/07a02b49-0586-4c72-be44-ffb635e63d62" />

### After
![fix-no-internet-container-scrolling](https://github.com/user-attachments/assets/3490a1eb-034f-48e1-9f46-4d40dc349dde)
